### PR TITLE
App never initializes because firebase.config is object not string 

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,8 +30,8 @@ module.exports.templateTags = [{
     }
   ],
   async run({ context }, type, email, password) {
-    if (!app && context.firebase && isJson(context.firebase.config)) {
-      app = initializeApp(JSON.parse(context.firebase.config))
+    if (!app && context.firebase) {
+      app = initializeApp(context.firebase.config)
     }
     if (app && email && password) {
       auth = await getAuth(app)
@@ -42,15 +42,6 @@ module.exports.templateTags = [{
     }
   },
 }]
-
-function isJson(str) {
-  try {
-    JSON.parse(str);
-  } catch (e) {
-    return false;
-  }
-  return true;
-}
 
 async function getUid(email, password) {
   return signInWithEmailAndPassword(auth, email, password)


### PR DESCRIPTION
im using somethin like this in the base Environment:
```json
{
  "firebase": {
    "config": {
      "apiKey": "KEY",
      "authDomain": "DEFAULT.firebaseapp.com",
      "databaseURL": "https://DEFAULT.firebaseio.com",
      "projectId": "DEFAULT",
      "storageBucket": "DEFAULT.appspot.com",
      "messagingSenderId": "SENDER_ID",
      "appId": "1:fffffffffffffffffffffffffff"
    }
  }
}
```

And the Token never got generated. 
The variable seems to be never a JSON String so I removed the check.
Maybe there should be a better check to verify the config is valid.